### PR TITLE
Add direct win32 call support for memory mapped files

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{ matrix.msystem }}
-          install: base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-dlfcn mingw-w64-clang-x86_64-boost mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc
+          install: base-devel curl zip mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-dlfcn mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc
           update: true
           location: '${{ steps.facts.outputs.drive }}\M'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: ${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
+          key: clang-${{ runner.os }}-${{ hashFiles('compiler+runtime/bin/build-clang') }}
       - name: Build Clang/LLVM
         run: |
           if [[ ! -e ${{ github.workspace }}/compiler+runtime/build/llvm-install/usr/local/bin/clang++ ]];
@@ -187,7 +187,7 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/compiler+runtime/build/llvm-install
-          key: ${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
+          key: clang-${{ runner.os }}-${{ hashFiles('${{ github.workspace }}/compiler+runtime/bin/build-clang') }}
       - name: Cache ccache object files
         if: matrix.analyze == 'off'
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/ikappaki/jank-win/actions/workflows/build-win.yml/badge.svg)](https://github.com/ikappaki/jank-win/actions/workflows/build-win.yml)
+[![CIWIN](https://github.com/ikappaki/jank-win/actions/workflows/build-win.yml/badge.svg)](https://github.com/ikappaki/jank-win/actions/workflows/build-win.yml) [![CI](https://github.com/ikappaki/jank-win/actions/workflows/build.yml/badge.svg)](https://github.com/ikappaki/jank-win/actions/workflows/build.yml)
 
 # jank on MS-Windows
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ git submodule update --init --recursive --jobs 8
 
 Install dependencies:
 ```sh
-pacman -S mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-dlfcn mingw-w64-clang-x86_64-boost mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc
+pacman -S mingw-w64-clang-x86_64-git-lfs mingw-w64-clang-x86_64-cmake mingw-w64-clang-x86_64-dlfcn mingw-w64-clang-x86_64-libffi mingw-w64-clang-x86_64-doctest mingw-w64-clang-x86_64-libzip mingw-w64-clang-x86_64-gc
 ```
 
 Download and install a precompiled *clang64* package with the required jank patches, If you prefer, instructions for building it locally are provided further below:

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -363,7 +363,6 @@ include(cmake/dependency/boost-multiprecision.cmake)
 
 find_package(LibZip REQUIRED)
 find_package(OpenSSL REQUIRED COMPONENTS Crypto)
-find_package(Boost CONFIG REQUIRED COMPONENTS iostreams)
 # ---- Other dependencies ----
 
 # ---- libjank.a ----
@@ -554,7 +553,6 @@ target_include_directories(
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/cpptrace/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/cppinterop/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/cppinterop/lib>"
-  "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/boost-iostreams/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/boost-preprocessor/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/boost-multiprecision/include>"
   "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/third-party/stduuid/include/>"

--- a/compiler+runtime/CMakeLists.txt
+++ b/compiler+runtime/CMakeLists.txt
@@ -568,7 +568,6 @@ target_link_libraries(
   libzippp::libzippp
   cpptrace::cpptrace
   ftxui::screen ftxui::dom
-  Boost::iostreams
   Boost::multiprecision
   nanobench_lib
   bdwgc::gc bdwgc::gctba
@@ -602,10 +601,7 @@ foreach(dir ${jank_lib_includes_prop})
   endif()
 endforeach()
 
-set(jank_lib_linker_flags_list "-lboost_iostreams-mt")
-
-# Get the full library path from the imported target
-get_target_property(boost_io_lib Boost::iostreams IMPORTED_LOCATION_RELEASE)
+set(jank_lib_linker_flags_list "")
 
 if(WIN32)
   list(APPEND jank_lib_linker_flags_list
@@ -738,7 +734,6 @@ target_link_libraries(
   libzip::zip z
   LLVM clang-cpp
   OpenSSL::Crypto
-  Boost::iostreams
 )
 
 if(WIN32)
@@ -746,6 +741,7 @@ if(WIN32)
     jank_exe_phase_1 PUBLIC
     ${jank_link_whole_start} ${CMAKE_BINARY_DIR}/libchkstk.a ${jank_link_whole_end}
 
+    zstd
     ws2_32
     dbghelp
   )
@@ -851,7 +847,6 @@ if(jank_test)
     LLVM clang-cpp
     OpenSSL::Crypto
     doctest::doctest
-    Boost::iostreams
   )
 
   if(WIN32)
@@ -859,6 +854,7 @@ if(jank_test)
       jank_test_exe PUBLIC
       ${jank_link_whole_start} ${CMAKE_BINARY_DIR}/libchkstk.a ${jank_link_whole_end}
 
+      zstd
       ws2_32
       dbghelp
     )

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -1,23 +1,10 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 
 #include <jank/runtime/object.hpp>
 #include <jtl/result.hpp>
-
-#ifdef _WIN32
-#include <windows.h>
-struct HANDLES
-{
-  HANDLE hFile;
-  HANDLE hMapping;
-  HANDLES() = delete;
-  HANDLES(HANDLE file, HANDLE mapping) : hFile(file), hMapping(mapping) {}
-};
-using mapped_file_handle = HANDLES;
-#else
-using mapped_file_handle = int;
-#endif
 
 namespace jank::runtime
 {
@@ -73,6 +60,20 @@ namespace jank::runtime::module
     jtl::immutable_string path;
   };
 
+#ifdef _WIN32
+#include <windows.h>
+  struct HANDLES
+  {
+    HANDLE hFile;
+    HANDLE hMapping;
+    HANDLES() = delete;
+    HANDLES(HANDLE file, HANDLE mapping) : hFile(file), hMapping(mapping) {}
+  };
+  using file_handle = HANDLES;
+#else
+  using file_handle = int;
+#endif
+
   /* When reading a file, we may find it on the filesystem or within a JAR. In the
    * first case, we map it with `mmap`, but we can't do that for JAR files since
    * we need to decompress them into memory. This `file_view` gives us one view
@@ -82,7 +83,7 @@ namespace jank::runtime::module
     file_view() = default;
     file_view(file_view const &) = delete;
     file_view(file_view &&) noexcept;
-    file_view(mapped_file_handle f, char const * const h, usize const s);
+    file_view(file_handle f, char const * const h, usize const s);
     file_view(jtl::immutable_string const &buff);
     ~file_view();
 
@@ -94,7 +95,7 @@ namespace jank::runtime::module
   private:
     /* In the case where we map a file, we track this information so we can read it and
      * later unmap it. */
-    std::optional<mapped_file_handle> fd{};
+    std::optional<file_handle> fd{};
     char const *head{};
     usize len{};
 

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -2,10 +2,22 @@
 
 #include <filesystem>
 
-#include <boost/iostreams/device/mapped_file.hpp>
-
 #include <jank/runtime/object.hpp>
 #include <jtl/result.hpp>
+
+#ifdef _WIN32
+#include <windows.h>
+struct HANDLES
+{
+  HANDLE hFile;
+  HANDLE hMapping;
+  HANDLES() = delete;
+  HANDLES(HANDLE file, HANDLE mapping) : hFile(file), hMapping(mapping) {}
+};
+using file_handle = HANDLES;
+#else
+using file_handle = int;
+#endif
 
 namespace jank::runtime
 {
@@ -70,7 +82,7 @@ namespace jank::runtime::module
     file_view() = default;
     file_view(file_view const &) = delete;
     file_view(file_view &&) noexcept;
-    file_view(boost::iostreams::mapped_file_source mfs, char const * const h, usize const s);
+    file_view(file_handle f, char const * const h, usize const s);
     file_view(jtl::immutable_string const &buff);
     ~file_view();
 
@@ -82,7 +94,7 @@ namespace jank::runtime::module
   private:
     /* In the case where we map a file, we track this information so we can read it and
      * later unmap it. */
-    boost::iostreams::mapped_file_source mfs;
+    std::optional<file_handle> fd{};
     char const *head{};
     usize len{};
 

--- a/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
+++ b/compiler+runtime/include/cpp/jank/runtime/module/loader.hpp
@@ -14,9 +14,9 @@ struct HANDLES
   HANDLES() = delete;
   HANDLES(HANDLE file, HANDLE mapping) : hFile(file), hMapping(mapping) {}
 };
-using file_handle = HANDLES;
+using mapped_file_handle = HANDLES;
 #else
-using file_handle = int;
+using mapped_file_handle = int;
 #endif
 
 namespace jank::runtime
@@ -82,7 +82,7 @@ namespace jank::runtime::module
     file_view() = default;
     file_view(file_view const &) = delete;
     file_view(file_view &&) noexcept;
-    file_view(file_handle f, char const * const h, usize const s);
+    file_view(mapped_file_handle f, char const * const h, usize const s);
     file_view(jtl::immutable_string const &buff);
     ~file_view();
 
@@ -94,7 +94,7 @@ namespace jank::runtime::module
   private:
     /* In the case where we map a file, we track this information so we can read it and
      * later unmap it. */
-    std::optional<file_handle> fd{};
+    std::optional<mapped_file_handle> fd{};
     char const *head{};
     usize len{};
 

--- a/compiler+runtime/src/cpp/jank/environment/check_health.cpp
+++ b/compiler+runtime/src/cpp/jank/environment/check_health.cpp
@@ -365,7 +365,7 @@ namespace jank::environment
     {
       auto const tmp{ std::filesystem::temp_directory_path() };
       std::string path_tmp = (tmp / "jank-aot-XXXXXX").string();
-      int fd = mkstemp(path_tmp.data());
+      const int fd = mkstemp(path_tmp.data());
       close(fd);
       std::filesystem::remove(path_tmp);
       std::filesystem::create_directories(path_tmp);
@@ -393,8 +393,8 @@ namespace jank::environment
 
       auto const stdout_file{ std::filesystem::path{ path_tmp } / "stdout" };
       auto const proc_code{ llvm::sys::ExecuteAndWait(
-        exe_output.string().c_str(),
-        { exe_output.string().c_str() },
+        exe_output.string(),
+        { exe_output.string() },
         std::nullopt,
         { std::nullopt, stdout_file.string().c_str(), std::nullopt },
         5) };

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -1,3 +1,8 @@
+#ifdef __MINGW64__
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#endif
 #include <fcntl.h>
 #include <unistd.h>
 

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -379,17 +379,17 @@ namespace jank::runtime::module
   }
 
   file_view::file_view(file_view &&mf) noexcept
-    : mfs{ std::move(mf.mfs) }
+    : fd{ mf.fd }
     , head{ mf.head }
     , len{ mf.len }
     , buff{ std::move(mf.buff) }
   {
-    mf.mfs = boost::iostreams::mapped_file_source();
+    mf.fd.reset();
     mf.head = nullptr;
   }
 
-  file_view::file_view(boost::iostreams::mapped_file_source mfs, char const * const h, size_t const s)
-    : mfs{ std::move(mfs) }
+  file_view::file_view(file_handle const f, char const * const h, usize const s)
+    : fd{ f }
     , head{ h }
     , len{ s }
   {
@@ -401,10 +401,26 @@ namespace jank::runtime::module
   }
 
   file_view::~file_view()
+
   {
-    if (mfs.is_open())
+    if(head != nullptr)
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast): I want const everywhere else. */
     {
-      mfs.close();
+#ifdef _WIN32
+      UnmapViewOfFile(head);
+#else
+      munmap(reinterpret_cast<void *>(const_cast<char *>(head)), len);
+#endif
+    }
+    if(fd.has_value())
+    {
+#ifdef _WIN32
+      CloseHandle(fd.value().hMapping);
+      CloseHandle(fd.value().hFile);
+#else
+      ::close(fd.value());
+#endif
+      fd.reset();
     }
   }
 
@@ -455,13 +471,76 @@ namespace jank::runtime::module
     {
       return err("File doesn't exist");
     }
-    boost::iostreams::mapped_file_source file;
-    file.open(path.data());
-    if(!file.is_open())
+
+#ifdef _WIN32
+    HANDLE hFile = CreateFileA(
+        path.c_str(),
+        GENERIC_READ,
+        FILE_SHARE_READ,
+        nullptr,
+        OPEN_EXISTING,
+        FILE_ATTRIBUTE_NORMAL,
+        nullptr
+    );
+
+    if (hFile == INVALID_HANDLE_VALUE)
+        return err("Unable to open file");
+
+    LARGE_INTEGER fileSize;
+    if (!GetFileSizeEx(hFile, &fileSize))
+    {
+        CloseHandle(hFile);
+        return err("Failed to get file size");
+    }
+
+    HANDLE hMapping = CreateFileMappingA(
+        hFile,
+        nullptr,
+        PAGE_READONLY,
+        0,
+        0,
+        nullptr
+    );
+
+    if (!hMapping)
+    {
+        CloseHandle(hFile);
+        return err("Failed to create file mapping");
+    }
+
+    auto head = static_cast<char const *>(MapViewOfFile(hMapping, FILE_MAP_READ, 0, 0, 0));
+    if (!head)
+    {
+        CloseHandle(hMapping);
+        CloseHandle(hFile);
+        return err("Failed to map view of file");
+    }
+
+    return ok(file_view{HANDLES(hFile, hMapping), head, static_cast<size_t>(fileSize.QuadPart)});
+
+#else
+  auto const file_size(std::filesystem::file_size(path.c_str()));
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-vararg) */
+    auto const fd(::open(path.c_str(), O_RDONLY));
+    if(fd < 0)
     {
       return err("Unable to open file");
     }
-    return ok(file_view{ std::move(file), file.data(), file.size() });
+    auto const head(
+      reinterpret_cast<char const *>(mmap(nullptr, file_size, PROT_READ, MAP_PRIVATE, fd, 0)));
+
+    /* MAP_FAILED is a macro which does a C-style cast. */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wold-style-cast"
+    /* NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast,performance-no-int-to-ptr) */
+    if(head == MAP_FAILED)
+#pragma clang diagnostic pop
+    {
+      return err("Mapping failed for unknown reason");
+    }
+
+    return ok(file_view{ fd, head, file_size });
+#endif
   }
 
   jtl::string_result<file_view> loader::read_file(jtl::immutable_string const &path)

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -4,8 +4,6 @@
 #include <filesystem>
 #include <regex>
 
-#include <boost/iostreams/device/mapped_file.hpp>
-
 #include <libzippp.h>
 
 #include <jank/util/fmt/print.hpp>

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -391,7 +391,7 @@ namespace jank::runtime::module
     mf.head = nullptr;
   }
 
-  file_view::file_view(file_handle const f, char const * const h, usize const s)
+  file_view::file_view(mapped_file_handle const f, char const * const h, usize const s)
     : fd{ f }
     , head{ h }
     , len{ s }

--- a/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
+++ b/compiler+runtime/src/cpp/jank/runtime/module/loader.cpp
@@ -391,7 +391,7 @@ namespace jank::runtime::module
     mf.head = nullptr;
   }
 
-  file_view::file_view(mapped_file_handle const f, char const * const h, usize const s)
+  file_view::file_view(file_handle const f, char const * const h, usize const s)
     : fd{ f }
     , head{ h }
     , len{ s }

--- a/compiler+runtime/src/cpp/jank/util/clang.cpp
+++ b/compiler+runtime/src/cpp/jank/util/clang.cpp
@@ -34,8 +34,8 @@ namespace jank::util
     auto const tmp{ std::filesystem::temp_directory_path() };
     std::string path_tmp = (tmp / "jank-clang-XXXXXX").string();
     mkstemp(path_tmp.data());
-    auto const proc_code{ llvm::sys::ExecuteAndWait(path.string().c_str(),
-                                                    { path.string().c_str(), "--version" },
+    auto const proc_code{ llvm::sys::ExecuteAndWait(path.string(),
+                                                    { path.string(), "--version" },
                                                     std::nullopt,
                                                     { std::nullopt, path_tmp, std::nullopt }) };
     if(proc_code < 0)

--- a/compiler+runtime/src/cpp/main.cpp
+++ b/compiler+runtime/src/cpp/main.cpp
@@ -163,7 +163,7 @@ namespace jank
      * and we reuse the same file over and over. */
     auto const tmp{ std::filesystem::temp_directory_path() };
     std::string path_tmp{ (tmp / "jank-repl-XXXXXX").string() };
-    int fd = mkstemp(path_tmp.data());
+    const int fd = mkstemp(path_tmp.data());
     close(fd);
 
     /* TODO: Completion. */


### PR DESCRIPTION
It removes `boost-iostreams` workaround in favour of direct win32 api calls. Addresses #4.