### PR TITLE
Fix find clang issue

### DIFF
--- a/compiler+runtime/src/cpp/jank/util/clang.cpp
+++ b/compiler+runtime/src/cpp/jank/util/clang.cpp
@@ -33,7 +33,8 @@ namespace jank::util
   {
     auto const tmp{ std::filesystem::temp_directory_path() };
     std::string path_tmp = (tmp / "jank-clang-XXXXXX").string();
-    mkstemp(path_tmp.data());
+    int fd = mkstemp(path_tmp.data());
+    close(fd);
     auto const proc_code{ llvm::sys::ExecuteAndWait(path.string(),
                                                     { path.string(), "--version" },
                                                     std::nullopt,


### PR DESCRIPTION
when the compiler is not installed in the original build path.