### PR TITLE
Do not suppose windows libs are prefixed with `lib`

### DIFF
--- a/compiler+runtime/src/cpp/jank/jit/processor.cpp
+++ b/compiler+runtime/src/cpp/jank/jit/processor.cpp
@@ -45,7 +45,7 @@ namespace jank::jit
   }
 #elif defined(_WIN32)
   {
-    return util::format("lib{}.dll", lib);
+    return util::format("{}.dll", lib);
   }
 #endif
 


### PR DESCRIPTION
Fixes #37.